### PR TITLE
added request header to allow cross site origin in the api call

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -24,7 +24,12 @@ class App extends Component {
   }
 
   componentDidMount = () => {
-    fetch("https://black-stories-matter-api.herokuapp.com/api/v1/books")
+    fetch("https://black-stories-matter-api.herokuapp.com/api/v1/books", {
+      //request headers
+      headers: {
+        'Access-Control-Allow-Origin': 'https://black-stories-matter-api.herokuapp.com'
+      }
+    })
       .then((response) => response.json())
       .then(
         (data) => {


### PR DESCRIPTION
### Type of change:
- [ *] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Styling - no new features

### Why is this change required? What problem(s) does it solve?
Basically your browser prevents websites (your heroku site) from accessing external websites (in this case the API) for security reasons. You need to explicitly grant permission. That's why you are seeing a CORS policy issue on your heroku site even when it works on your local dev version. 

### Were there any challenges while implementing this feature? If so, how were they addressed?
The API is hard coded to only accept requests from 'http://blackstoriesmatter.herokuapp.com' so I cannot test it directly myself. 
[Check line 44](https://github.com/Black-Stories-Matter/black_stories_matter_api/blob/master/config/application.rb). But I have run your app in development mode on my own machine and confirmed that the request header is present. ![See screenshot](https://user-images.githubusercontent.com/42697100/96524887-c0356680-1279-11eb-86a4-73a3a6c2c2d4.png)

If that still doesn't work you can replace try replacing the API url with '*'. The star symbol is a wildcard character that basically says 'allow any url'. 

### Where should the reviewer start? How can this be tested?
Merge the pull request, run the dev version locally, confirm that the Access-Control-Allow-Origin header is present in the fetch request, try deploying it on heroku using your normal deployment method. 

### Link issues
https://github.com/Black-Stories-Matter/black-stories-matter-fe/issues/5